### PR TITLE
Update package.json start & build script calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.4",
   "description": "OpenUI5 template app build with gulp.",
   "scripts": {
-    "start": "node_modules/gulp/bin/gulp.js --silent",
-    "start:verbose": "node_modules/gulp/bin/gulp.js",
-    "build": "node_modules/gulp/bin/gulp.js build --silent",
-    "build:verbose": "node_modules/gulp/bin/gulp.js build",
+    "start": "node node_modules/gulp/bin/gulp.js --silent",
+    "start:verbose": "node node_modules/gulp/bin/gulp.js",
+    "build": "node node_modules/gulp/bin/gulp.js build --silent",
+    "build:verbose": "node node_modules/gulp/bin/gulp.js build",
     "precommit": "lint-staged"
   },
   "lint-staged": {


### PR DESCRIPTION
Added ```node``` keword before the path to gulp.

Necessary on (windows) systems so the ```.js``` file will actually be executed by node.  
In my case I had the default program to open ```.js``` files set to be sublime, so the code never got exectued, just opened in my text editor :smile:.

If we have a look at several bigger projects, adding ```node``` in front of the path to the executed file seems to be best practice:

- [Vue](https://github.com/vuejs/vue/blob/4fd2ce813cd0a59bd544defe07f44a5731e45f84/package.json#L24)
- [Webpack](https://github.com/webpack/webpack/blob/6b5ffa4d70b3d0e47c836196f217d8826604b723/package.json#L98)
- [React](https://github.com/facebook/react/blob/7bdf93b17a35a5d8fcf0ceae0bf48ed5e6b16688/package.json#L104)